### PR TITLE
KMA-6 - set up jenkins deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('jenkins-jobs@kma-6-pipeline-deployments-for-scale-of-belief-lambda') _
+@Library('jenkins-jobs') _
 
 serverlessPipeline(
     hipchatRoom: 'scale-of-belief',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+#!groovy
+@Library('jenkins-jobs@kma-6-pipeline-deployments-for-scale-of-belief-lambda') _
+
+serverlessPipeline(
+    hipchatRoom: 'KMA-6-testing-jenkins-hipchat-messages'
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 @Library('jenkins-jobs@kma-6-pipeline-deployments-for-scale-of-belief-lambda') _
 
 serverlessPipeline(
-    hipchatRoom: 'KMA-6-testing-jenkins-hipchat-messages',
+    hipchatRoom: 'scale-of-belief',
     defaultEnvironment: 'production'
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 @Library('jenkins-jobs@kma-6-pipeline-deployments-for-scale-of-belief-lambda') _
 
 serverlessPipeline(
-    hipchatRoom: 'KMA-6-testing-jenkins-hipchat-messages'
+    hipchatRoom: 'KMA-6-testing-jenkins-hipchat-messages',
+    defaultEnvironment: 'production'
 )

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,6 +27,7 @@ functions:
 package:
   exclude:
     - .git/**
+    - .deployment/**
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
This adds a simple Jenkinsfile that (using jenkins-jobs' shared library) defines a deployment pipeline.

Depends on https://github.com/CruGlobal/jenkins-jobs/pull/43.
This supports https://jira.cru.org/browse/KMA-6.