### PR TITLE
UDP-64 - Fix adobecampaign data

### DIFF
--- a/__mocks__/redis.js
+++ b/__mocks__/redis.js
@@ -1,18 +1,32 @@
+const EventEmitter = require('events');
+
 const LAST_SUCCESS = '2018-07-30T14:28:44.700Z'
 const dataStore = { 'scale-of-belief-import-campaign-last-success': LAST_SUCCESS };
 
+class RedisClient extends EventEmitter {
+  constructor () {
+    super();
+    this.connected = true;
+  }
+
+  get (key, callback) {
+    callback(null, dataStore[key]);
+  }
+
+  set (key, value, callback) {
+    dataStore[key] = value;
+    callback(null, null);
+  }
+
+  quit () {
+    this.connected = false;
+    super.emit('end');
+  }
+}
+
+
 module.exports = {
   createClient: (port, address) => {
-    return {
-      on: (type, callback) => {
-        callback();
-      },
-      get: (key) => {
-        return dataStore[key];
-      },
-      set: (key, value) => {
-        dataStore[key] = value;
-      }
-    };
+    return new RedisClient();
   }
 }

--- a/__mocks__/snowplow-tracker.js
+++ b/__mocks__/snowplow-tracker.js
@@ -1,0 +1,20 @@
+let emitterCallback;
+
+module.exports = {
+  emitter: (endpoint, protocol, port, method, bufferSize, callback, agentOptions) => {
+    return {
+      flush: (mockBody) => {
+        callback(null, mockBody, 'ok');
+      },
+      input: (payload) => {
+        console.log('payload:', payload);
+      }
+    };
+  },
+  tracker: (emitters, namespace, app_id, base64) => {
+    return {
+      addPayloadPair: jest.fn(),
+      trackStructEvent: jest.fn()
+    };
+  }
+}

--- a/campaign/import.js
+++ b/campaign/import.js
@@ -13,6 +13,19 @@ const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
 const LAST_SUCCESS_KEY = 'scale-of-belief-import-campaign-last-success';
 let redisClient;
+let eventTracker;
+
+// -1 to differentiate between 0 result files
+let numOpens = -1;
+let finishedOpens = 0;
+let numClicks = -1;
+let finishedClicks = 0;
+let numSubs = -1;
+let finishedSubs = 0;
+let numUnsubs = -1;
+let finishedUnsubs = 0;
+
+let dayCount = 0;
 
 const self = module.exports = {
   /* istanbul ignore next */
@@ -27,9 +40,26 @@ const self = module.exports = {
           throw new Error('Error connecting to Redis: ' + error);
         });
 
+        eventTracker = snowplow.getSnowplowEventTracker();
+        eventTracker.on('ping', (eventType, numProcessed) => {
+          switch (eventType) {
+            case 'open-email':
+              finishedOpens = finishedOpens + numProcessed;
+              break;
+            case 'click-link':
+              finishedClicks = finishedClicks + numProcessed;
+              break;
+            case 'subscribe':
+              finishedSubs = finishedSubs + numProcessed;
+              break;
+            case 'unsubscribe':
+              finishedUnsubs = finishedUnsubs + numProcessed;
+              break;
+          }
+        });
+
         let lastSuccessfulDate = await getAsync(LAST_SUCCESS_KEY);
         let today = new Date();
-        let count = 0;
 
         let dateToProcess = moment(lastSuccessfulDate);
         let formattedDate;
@@ -37,24 +67,55 @@ const self = module.exports = {
           dateToProcess = dateToProcess.add(1, 'days');
           formattedDate = util.buildFormattedDate(new Date(dateToProcess.valueOf()));
 
-          await self.trackEvents(formattedDate, 'opens');
-          await self.trackEvents(formattedDate, 'clicks');
-          await self.trackEvents(formattedDate, 'subscriptions');
-          await self.trackEvents(formattedDate, 'unsubscriptions');
-          count++;
+          numOpens = await self.trackEvents(formattedDate, 'opens');
+          numClicks = await self.trackEvents(formattedDate, 'clicks');
+          numSubs = await self.trackEvents(formattedDate, 'subscriptions');
+          numUnsubs = await self.trackEvents(formattedDate, 'unsubscriptions');
+          dayCount++;
         }
 
-        console.log(`Ran ${count} day(s) of data.`);
+        console.log(`Ran ${dayCount} day(s) of data.`);
         await self.updateLastSuccess();
       } catch (error) {
         throw new Error(error);
       }
     };
 
+    let timer;
+
+    const eventsHaveFinished = () => {
+      if (dayCount === 0) {
+        eventTracker.emit('end');
+        return;
+      }
+
+      if (numOpens === -1 || numClicks === -1 || numSubs === -1 || numUnsubs === -1) {
+        console.log('Something is still -1');
+        return;
+      }
+
+      if (finishedOpens >= numOpens
+        && finishedClicks >= numClicks
+        && finishedSubs >= numSubs
+        && finishedUnsubs >= numUnsubs) {
+
+        eventTracker.emit('end');
+      }
+    }
+
     /* istanbul ignore next */
     handleCampaignData().then(() => {
       redisClient.quit();
-      callback(null, { statusCode: 204 });
+
+      // Constantly check for more events until they're all done
+      timer = setInterval(eventsHaveFinished, 3000);
+
+      eventTracker.on('end', () => {
+        if (timer) {
+          clearInterval(timer);
+        }
+        callback(null, { statusCode: 204 });
+      })
     }).catch((error) => {
       if (redisClient) {
         redisClient.quit();
@@ -68,7 +129,9 @@ const self = module.exports = {
       let csvData = await self.getDataFromS3(fileName);
       let parsedData = await self.parseDataFromCsv(csvData);
       await self.sendEventsToSnowplow(parsedData, type);
+      return parsedData.length;
     }
+    return 0;
   },
   determineFileName: (type, formattedDate) => {
     const params = {

--- a/campaign/snowplow-event-tracker.js
+++ b/campaign/snowplow-event-tracker.js
@@ -1,0 +1,5 @@
+const EventEmitter = require('events');
+
+class SnowplowEventTracker extends EventEmitter {}
+
+module.exports = SnowplowEventTracker;

--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -150,5 +150,9 @@ module.exports = {
   },
   getSnowplowEventTracker: () => {
     return eventTracker;
+  },
+  // For testing purposes only
+  getEmitter: () => {
+    return emitter;
   }
 };

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -10,11 +10,6 @@ describe('Campaign Snowplow', () => {
   const scoreSchema = 'iglu:org.cru/content-scoring/jsonschema/1-0-0';
 
   it('Should track an open event with an external campaign code', () => {
-    const mockEmitter = {
-      flush: () => {}
-    };
-    jest.spyOn(snowplow, 'emitter').mockImplementation(() => mockEmitter);
-
     const mockTrackStructEvent = jest.fn();
     const mockAddPayloadPair = jest.fn();
 
@@ -65,11 +60,6 @@ describe('Campaign Snowplow', () => {
   });
 
   it('Should track an open event without an external campaign code', () => {
-      const mockEmitter = {
-        flush: () => {}
-      };
-      jest.spyOn(snowplow, 'emitter').mockImplementation(() => mockEmitter);
-
       const mockTrackStructEvent = jest.fn();
       const mockAddPayloadPair = jest.fn();
 
@@ -119,11 +109,6 @@ describe('Campaign Snowplow', () => {
     });
 
     it('Should track an open event with an sso guid', () => {
-      const mockEmitter = {
-        flush: () => {}
-      };
-      jest.spyOn(snowplow, 'emitter').mockImplementation(() => mockEmitter);
-
       const mockTrackStructEvent = jest.fn();
       const mockAddPayloadPair = jest.fn();
 
@@ -174,11 +159,6 @@ describe('Campaign Snowplow', () => {
     });
 
     it('Should track a click event with an external campaign code and sso guid', () => {
-      const mockEmitter = {
-        flush: () => {}
-      };
-      jest.spyOn(snowplow, 'emitter').mockImplementation(() => mockEmitter);
-
       const mockTrackStructEvent = jest.fn();
       const mockAddPayloadPair = jest.fn();
 
@@ -231,11 +211,6 @@ describe('Campaign Snowplow', () => {
     });
 
     it('Should track a subscription event', () => {
-      const mockEmitter = {
-        flush: () => {}
-      };
-      jest.spyOn(snowplow, 'emitter').mockImplementation(() => mockEmitter);
-
       const mockTrackStructEvent = jest.fn();
       const mockAddPayloadPair = jest.fn();
 
@@ -287,11 +262,6 @@ describe('Campaign Snowplow', () => {
     });
 
     it('Should track an unsubscription event', () => {
-      const mockEmitter = {
-        flush: () => {}
-      };
-      jest.spyOn(snowplow, 'emitter').mockImplementation(() => mockEmitter);
-
       const mockTrackStructEvent = jest.fn();
       const mockAddPayloadPair = jest.fn();
 
@@ -340,5 +310,25 @@ describe('Campaign Snowplow', () => {
 
       expect(mockAddPayloadPair).toHaveBeenCalledWith('url', uri);
       expect(mockAddPayloadPair).toHaveBeenCalledWith('page', 'Service Label');
+    });
+
+    describe('Event Tracker', () => {
+      it('should emit a "ping" event on emitter callback', done => {
+        const requestBody = JSON.stringify({ data: [{ se_ac: 'open-email' }] });
+        const mockBody = {
+          request: {
+            body: requestBody
+          }
+        };
+
+        const eventTracker = campaignSnowplow.getSnowplowEventTracker();
+        eventTracker.on('ping', (eventType, numProcessed) => {
+          expect(eventType).toEqual('open-email');
+          expect(numProcessed).toEqual(1);
+          done();
+        });
+
+        campaignSnowplow.getEmitter().flush(mockBody);
+      });
     });
 });


### PR DESCRIPTION
This PR will fix the dropped events for bulk adobe campaign data loads each day by waiting for all of the events to pass through the snowplow emitter's callback. 

Basically, we get the lines of each csv file and check them against the number of events that snowplow has sent off. When these numbers are equal (or somehow events is larger, I haven't run across this yet) then we finish out the infinite loop (by `setInterval`). 