### PR TITLE
UDP-65 - Fix undefined IDs

### DIFF
--- a/campaign/import.test.js
+++ b/campaign/import.test.js
@@ -20,7 +20,7 @@ describe('Campaign Import', () => {
       expect(parsedData.length).toEqual(2); // 2 records in the CSV
 
       const firstRecord = parsedData[0];
-      expect(firstRecord['adobe_campaign_id']).toEqual('CMP64');
+      expect(firstRecord['adobe_campaign_label']).toEqual('Bill R Test Campaign 1');
       expect(firstRecord['ext_campaign_code']).toEqual('bill-test-campaign');
       expect(firstRecord['delivery_label']).toEqual('[2018/07/26] Multilingual email (Chinese)');
       expect(firstRecord['sso_guid']).toEqual('test-guid-1');
@@ -29,7 +29,7 @@ describe('Campaign Import', () => {
       expect(firstRecord['click_url']).toEqual('https://google.com');
 
       const secondRecord = parsedData[1];
-      expect(secondRecord['adobe_campaign_id']).toEqual('CMP64');
+      expect(secondRecord['adobe_campaign_label']).toEqual('Bill R Test Campaign 1');
       expect(secondRecord['ext_campaign_code']).toEqual('bill-test-campaign');
       expect(secondRecord['delivery_label']).toEqual('[2018/07/26] Multilingual email (Chinese)');
       expect(secondRecord['sso_guid']).toEqual('test-guid-2');
@@ -50,7 +50,7 @@ describe('Campaign Import', () => {
       expect(parsedData.length).toEqual(3); // 3 records in the CSV
 
       const firstRecord = parsedData[0];
-      expect(firstRecord['adobe_campaign_id']).toEqual('CMP64');
+      expect(firstRecord['adobe_campaign_label']).toEqual('Bill R Test Campaign 1');
       expect(firstRecord['ext_campaign_code']).toEqual('bill-test-campaign');
       expect(firstRecord['delivery_label']).toEqual('[2018/07/26] Multilingual email (Chinese)');
       expect(firstRecord['sso_guid']).toEqual('test-guid-1');
@@ -58,7 +58,7 @@ describe('Campaign Import', () => {
       expect(firstRecord['log_date']).toEqual('2018-07-30T09:20:49.557');
 
       const secondRecord = parsedData[1];
-      expect(secondRecord['adobe_campaign_id']).toEqual('CMP64');
+      expect(secondRecord['adobe_campaign_label']).toEqual('Bill R Test Campaign 1');
       expect(secondRecord['ext_campaign_code']).toEqual('bill-test-campaign');
       expect(secondRecord['delivery_label']).toEqual('[2018/07/26] Multilingual email (Chinese)');
       expect(secondRecord['sso_guid']).toEqual('test-guid-2');
@@ -66,7 +66,7 @@ describe('Campaign Import', () => {
       expect(secondRecord['log_date']).toEqual('2018-07-30T09:12:33.310');
 
       const thirdRecord = parsedData[2];
-      expect(thirdRecord['adobe_campaign_id']).toEqual('CMP64');
+      expect(thirdRecord['adobe_campaign_label']).toEqual('Bill R Test Campaign 1');
       expect(thirdRecord['ext_campaign_code']).toEqual('bill-test-campaign');
       expect(thirdRecord['delivery_label']).toEqual('[2018/07/26] Multilingual email (Chinese)');
       expect(thirdRecord['sso_guid']).toEqual('test-guid-2');
@@ -86,7 +86,6 @@ describe('Campaign Import', () => {
       expect(parsedData.length).toEqual(2); // 2 records in the CSV
 
       const firstRecord = parsedData[0];
-      expect(firstRecord['service_id']).toEqual('SVC40');
       expect(firstRecord['service_label']).toEqual('Bill Newsletter');
       expect(firstRecord['origin']).toEqual('Bill Origin');
       expect(firstRecord['sso_guid']).toEqual('test-guid-1');
@@ -94,7 +93,6 @@ describe('Campaign Import', () => {
       expect(firstRecord['log_date']).toEqual('2018-08-10T17:04:50.419');
 
       const secondRecord = parsedData[1];
-      expect(firstRecord['service_id']).toEqual('SVC40');
       expect(firstRecord['service_label']).toEqual('Bill Newsletter');
       expect(firstRecord['origin']).toEqual('Bill Origin');
       expect(secondRecord['sso_guid']).toEqual('test-guid-2');
@@ -115,7 +113,6 @@ describe('Campaign Import', () => {
       expect(parsedData.length).toEqual(2); // 2 records in the CSV
 
       const firstRecord = parsedData[0];
-      expect(firstRecord['service_id']).toEqual('SVC40');
       expect(firstRecord['service_label']).toEqual('Bill Newsletter');
       expect(firstRecord['origin']).toEqual('Bill Origin');
       expect(firstRecord['sso_guid']).toEqual('test-guid-1');
@@ -123,7 +120,6 @@ describe('Campaign Import', () => {
       expect(firstRecord['log_date']).toEqual('2018-08-13T17:02:55.224');
 
       const secondRecord = parsedData[1];
-      expect(firstRecord['service_id']).toEqual('SVC40');
       expect(firstRecord['service_label']).toEqual('Bill Newsletter');
       expect(firstRecord['origin']).toEqual('Bill Origin');
       expect(secondRecord['sso_guid']).toEqual('test-guid-2');

--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -35,7 +35,7 @@ const track = (data, action) => {
     data[element] = util.removeNonDisplayable(data[element]);
   });
 
-  const tracker = snowplow.tracker([emitter], 'ac', 'adobecampaign', false);
+  const tracker = snowplow.tracker([emitter], 'adobecampaign-nodejs', 'adobecampaign', false);
 
   const ssoGuid = data['sso_guid'];
   const grMasterPersonId = data['gr_master_person_id'];

--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -96,7 +96,7 @@ const track = (data, action) => {
     'campaign',
     action,
     label, // label
-    property,
+    property || null,
     null, // value
     customContexts,
     logDate.valueOf()
@@ -108,7 +108,9 @@ const buildUri = (action, data) => {
 
   let identifier;
 
-  if (data['delivery_label']) {
+  if (data['adobe_campaign_label']) {
+    identifier = encodeURIComponent(data['adobe_campaign_label']);
+  } else if (data['delivery_label']) {
     identifier = encodeURIComponent(data['delivery_label']);
   } else if (data['service_label']) {
     identifier = encodeURIComponent(data['service_label']);

--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -110,8 +110,8 @@ const buildUri = (action, data) => {
 
   if (data['delivery_label']) {
     identifier = encodeURIComponent(data['delivery_label']);
-  } else if (data['service_id']) {
-    identifier = encodeURIComponent(data['service_id']);
+  } else if (data['service_label']) {
+    identifier = encodeURIComponent(data['service_label']);
   }
 
   uri = `${uri}/${identifier}`;

--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -108,10 +108,9 @@ const buildUri = (action, data) => {
 
   let identifier;
 
-  if (data['adobe_campaign_id']) {
-    identifier = encodeURIComponent(data['adobe_campaign_id']);
-  }
-  if (data['service_id']) {
+  if (data['delivery_label']) {
+    identifier = encodeURIComponent(data['delivery_label']);
+  } else if (data['service_id']) {
     identifier = encodeURIComponent(data['service_id']);
   }
 

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -233,7 +233,7 @@ describe('Campaign Snowplow', () => {
       campaignSnowplow.trackEvent(data, 'subscriptions');
       expect(trackerSpy).toHaveBeenCalled();
 
-      const uri = 'campaign://subscribe/service-id';
+      const uri = 'campaign://subscribe/Service%20Label';
 
       const customContexts = [
         {
@@ -284,7 +284,7 @@ describe('Campaign Snowplow', () => {
       campaignSnowplow.trackEvent(data, 'unsubscriptions');
       expect(trackerSpy).toHaveBeenCalled();
 
-      const uri = 'campaign://unsubscribe/service-id';
+      const uri = 'campaign://unsubscribe/Service%20Label';
 
       const customContexts = [
         {

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -22,7 +22,6 @@ describe('Campaign Snowplow', () => {
     const data = {
       ext_campaign_code: 'campaign-code',
       delivery_label: 'Some_Label - with [square brackets] (11/7/18) v.2',
-      adobe_campaign_label: 'Campaign Label',
       gr_master_person_id: 'some-gr-id',
       log_date: '2018-07-30T09:20:49.333'
     };
@@ -49,7 +48,7 @@ describe('Campaign Snowplow', () => {
       'campaign',
       'open-email',
       'campaign-code',
-      'Campaign Label',
+      null,
       null,
       customContexts,
       Date.parse(data['log_date']));
@@ -70,7 +69,6 @@ describe('Campaign Snowplow', () => {
 
       const data = {
         delivery_label: 'Some Label',
-        adobe_campaign_label: 'Campaign Label',
         gr_master_person_id: 'some-gr-id',
         log_date: '2018-07-30T09:20:49.557'
       };
@@ -97,7 +95,7 @@ describe('Campaign Snowplow', () => {
         'campaign',
         'open-email',
         null,
-        'Campaign Label',
+        null,
         null,
         customContexts,
         Date.parse(data['log_date']));
@@ -118,7 +116,6 @@ describe('Campaign Snowplow', () => {
 
       const data = {
         delivery_label: 'Some Label',
-        adobe_campaign_label: 'Campaign Label',
         sso_guid: 'some-guid',
         gr_master_person_id: 'some-gr-id',
         log_date: '2018-07-30T09:20:49.000'
@@ -146,7 +143,7 @@ describe('Campaign Snowplow', () => {
         'campaign',
         'open-email',
         null,
-        'Campaign Label',
+        null,
         null,
         customContexts,
         Date.parse(data['log_date']));
@@ -168,7 +165,6 @@ describe('Campaign Snowplow', () => {
       const data = {
         ext_campaign_code: 'campaign-code',
         delivery_label: 'Some Label',
-        adobe_campaign_label: 'Campaign Label',
         sso_guid: 'some-guid',
         gr_master_person_id: 'some-gr-id',
         log_date: '2018-07-30T09:20:49.454',
@@ -179,6 +175,55 @@ describe('Campaign Snowplow', () => {
       expect(trackerSpy).toHaveBeenCalled();
 
       const uri = 'campaign://click-link/Some%20Label/campaign-code';
+
+      const customContexts = [
+        {
+          schema: idSchema,
+          data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid' }
+        },
+        {
+          schema: scoreSchema,
+          data: {
+            uri: uri
+          }
+        }
+      ];
+
+      expect(mockTrackStructEvent).toHaveBeenCalledWith(
+        'campaign',
+        'click-link',
+        'https://www.cru.org',
+        null,
+        null,
+        customContexts,
+        Date.parse(data['log_date']));
+
+      expect(mockAddPayloadPair).toHaveBeenCalledWith('url', uri);
+      expect(mockAddPayloadPair).toHaveBeenCalledWith('page', 'Some Label');
+    });
+
+    it('Should use the adobe campaign label if it exists', () => {
+      const mockTrackStructEvent = jest.fn();
+      const mockAddPayloadPair = jest.fn();
+
+      const mockTracker = {
+        addPayloadPair: mockAddPayloadPair,
+        trackStructEvent: mockTrackStructEvent
+      }
+      const trackerSpy = jest.spyOn(snowplow, 'tracker').mockImplementation(() => mockTracker);
+
+      const data = {
+        adobe_campaign_label: 'Campaign Label',
+        delivery_label: 'Some Label',
+        sso_guid: 'some-guid',
+        gr_master_person_id: 'some-gr-id',
+        log_date: '2018-07-30T09:20:49.454',
+        click_url: 'https://www.cru.org'
+      };
+
+      campaignSnowplow.trackEvent(data, 'clicks');
+
+      const uri = 'campaign://click-link/Campaign%20Label';
 
       const customContexts = [
         {

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -20,7 +20,6 @@ describe('Campaign Snowplow', () => {
     const trackerSpy = jest.spyOn(snowplow, 'tracker').mockImplementation(() => mockTracker);
 
     const data = {
-      adobe_campaign_id: 'some-id',
       ext_campaign_code: 'campaign-code',
       delivery_label: 'Some_Label - with [square brackets] (11/7/18) v.2',
       adobe_campaign_label: 'Campaign Label',
@@ -70,7 +69,6 @@ describe('Campaign Snowplow', () => {
       const trackerSpy = jest.spyOn(snowplow, 'tracker').mockImplementation(() => mockTracker);
 
       const data = {
-        adobe_campaign_id: 'some-id',
         delivery_label: 'Some Label',
         adobe_campaign_label: 'Campaign Label',
         gr_master_person_id: 'some-gr-id',
@@ -119,7 +117,6 @@ describe('Campaign Snowplow', () => {
       const trackerSpy = jest.spyOn(snowplow, 'tracker').mockImplementation(() => mockTracker);
 
       const data = {
-        adobe_campaign_id: 'some-id',
         delivery_label: 'Some Label',
         adobe_campaign_label: 'Campaign Label',
         sso_guid: 'some-guid',
@@ -169,7 +166,6 @@ describe('Campaign Snowplow', () => {
       const trackerSpy = jest.spyOn(snowplow, 'tracker').mockImplementation(() => mockTracker);
 
       const data = {
-        adobe_campaign_id: 'some-id',
         ext_campaign_code: 'campaign-code',
         delivery_label: 'Some Label',
         adobe_campaign_label: 'Campaign Label',
@@ -221,7 +217,6 @@ describe('Campaign Snowplow', () => {
       const trackerSpy = jest.spyOn(snowplow, 'tracker').mockImplementation(() => mockTracker);
 
       const data = {
-        service_id: 'service-id',
         service_label: 'Service Label',
         cru_service_name: 'Cru Service Name',
         origin: 'origin',
@@ -272,7 +267,6 @@ describe('Campaign Snowplow', () => {
       const trackerSpy = jest.spyOn(snowplow, 'tracker').mockImplementation(() => mockTracker);
 
       const data = {
-        service_id: 'service-id',
         service_label: 'Service Label',
         cru_service_name: 'Cru Service Name',
         origin: 'origin',

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -31,7 +31,7 @@ describe('Campaign Snowplow', () => {
     campaignSnowplow.trackEvent(data, 'opens');
     expect(trackerSpy).toHaveBeenCalled();
 
-    const uri = 'campaign://open-email/some-id/campaign-code';
+    const uri = 'campaign://open-email/Some%20Label/campaign-code';
 
     const customContexts = [
       {
@@ -80,7 +80,7 @@ describe('Campaign Snowplow', () => {
       campaignSnowplow.trackEvent(data, 'opens');
       expect(trackerSpy).toHaveBeenCalled();
 
-      const uri = 'campaign://open-email/some-id';
+      const uri = 'campaign://open-email/Some%20Label';
 
       const customContexts = [
         {
@@ -130,7 +130,7 @@ describe('Campaign Snowplow', () => {
       campaignSnowplow.trackEvent(data, 'opens');
       expect(trackerSpy).toHaveBeenCalled();
 
-      const uri = 'campaign://open-email/some-id';
+      const uri = 'campaign://open-email/Some%20Label';
 
       const customContexts = [
         {
@@ -182,7 +182,7 @@ describe('Campaign Snowplow', () => {
       campaignSnowplow.trackEvent(data, 'clicks');
       expect(trackerSpy).toHaveBeenCalled();
 
-      const uri = 'campaign://click-link/some-id/campaign-code';
+      const uri = 'campaign://click-link/Some%20Label/campaign-code';
 
       const customContexts = [
         {

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -22,7 +22,7 @@ describe('Campaign Snowplow', () => {
     const data = {
       adobe_campaign_id: 'some-id',
       ext_campaign_code: 'campaign-code',
-      delivery_label: 'Some Label',
+      delivery_label: 'Some_Label - with [square brackets] (11/7/18) v.2',
       adobe_campaign_label: 'Campaign Label',
       gr_master_person_id: 'some-gr-id',
       log_date: '2018-07-30T09:20:49.333'
@@ -31,7 +31,7 @@ describe('Campaign Snowplow', () => {
     campaignSnowplow.trackEvent(data, 'opens');
     expect(trackerSpy).toHaveBeenCalled();
 
-    const uri = 'campaign://open-email/Some%20Label/campaign-code';
+    const uri = 'campaign://open-email/Some_Label%20-%20with%20%5Bsquare%20brackets%5D%20(11%2F7%2F18)%20v.2/campaign-code';
 
     const customContexts = [
       {
@@ -56,7 +56,7 @@ describe('Campaign Snowplow', () => {
       Date.parse(data['log_date']));
 
     expect(mockAddPayloadPair).toHaveBeenCalledWith('url', uri);
-    expect(mockAddPayloadPair).toHaveBeenCalledWith('page', 'Some Label');
+    expect(mockAddPayloadPair).toHaveBeenCalledWith('page', data['delivery_label']);
   });
 
   it('Should track an open event without an external campaign code', () => {

--- a/test/fixtures/campaign/clicks.csv
+++ b/test/fixtures/campaign/clicks.csv
@@ -1,3 +1,3 @@
-gr_master_person_id,sso_guid,delivery_label,ext_campaign_code,adobe_campaign_id,adobe_campaign_label,log_date,click_url
-"test-gr-master-person-id","test-guid-1","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","CMP64","Bill R Test Campaign 1","2018-07-30T09:20:49.000","https://google.com"
-"test-gr-master-person-id","test-guid-2","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","CMP64","Bill R Test Campaign 1","2018-07-30T09:12:30.000","https://www.cru.org"
+gr_master_person_id,sso_guid,delivery_label,ext_campaign_code,adobe_campaign_label,log_date,click_url
+"test-gr-master-person-id","test-guid-1","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","Bill R Test Campaign 1","2018-07-30T09:20:49.000","https://google.com"
+"test-gr-master-person-id","test-guid-2","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","Bill R Test Campaign 1","2018-07-30T09:12:30.000","https://www.cru.org"

--- a/test/fixtures/campaign/opens.csv
+++ b/test/fixtures/campaign/opens.csv
@@ -1,4 +1,4 @@
-gr_master_person_id,sso_guid,delivery_label,ext_campaign_code,adobe_campaign_id,adobe_campaign_label,log_date
-"test-gr-master-person-id","test-guid-1","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","CMP64","Bill R Test Campaign 1","2018-07-30T09:20:49.557"
-"test-gr-master-person-id","test-guid-2","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","CMP64","Bill R Test Campaign 1","2018-07-30T09:12:33.310"
-"test-gr-master-person-id","test-guid-2","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","CMP64","Bill R Test Campaign 1","2018-07-30T09:12:30.000"
+gr_master_person_id,sso_guid,delivery_label,ext_campaign_code,adobe_campaign_label,log_date
+"test-gr-master-person-id","test-guid-1","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","Bill R Test Campaign 1","2018-07-30T09:20:49.557"
+"test-gr-master-person-id","test-guid-2","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","Bill R Test Campaign 1","2018-07-30T09:12:33.310"
+"test-gr-master-person-id","test-guid-2","[2018/07/26] Multilingual email (Chinese)","bill-test-campaign","Bill R Test Campaign 1","2018-07-30T09:12:30.000"

--- a/test/fixtures/campaign/subscriptions.csv
+++ b/test/fixtures/campaign/subscriptions.csv
@@ -1,3 +1,3 @@
-gr_master_person_id,sso_guid,service_id,service_label,cru_service_name,origin,log_date
-"test-gr-master-person-id","test-guid-1","SVC40","Bill Newsletter","Special Service Name","Bill Origin","2018-08-10T17:04:50.419"
-"test-gr-master-person-id","test-guid-2","SVC40","Bill Newsletter","Special Service Name","Bill Origin","2018-08-10T17:04:50.419"
+gr_master_person_id,sso_guid,service_label,cru_service_name,origin,log_date
+"test-gr-master-person-id","test-guid-1","Bill Newsletter","Special Service Name","Bill Origin","2018-08-10T17:04:50.419"
+"test-gr-master-person-id","test-guid-2","Bill Newsletter","Special Service Name","Bill Origin","2018-08-10T17:04:50.419"

--- a/test/fixtures/campaign/unsubscriptions.csv
+++ b/test/fixtures/campaign/unsubscriptions.csv
@@ -1,3 +1,3 @@
-gr_master_person_id,sso_guid,service_id,service_label,origin,log_date
-"test-gr-master-person-id","test-guid-1","SVC40","Bill Newsletter","Bill Origin","2018-08-13T17:02:55.224"
-"test-gr-master-person-id","test-guid-2","SVC40","Bill Newsletter","Bill Origin","2018-08-13T17:02:55.224"
+gr_master_person_id,sso_guid,service_label,origin,log_date
+"test-gr-master-person-id","test-guid-1","Bill Newsletter","Bill Origin","2018-08-13T17:02:55.224"
+"test-gr-master-person-id","test-guid-2","Bill Newsletter","Bill Origin","2018-08-13T17:02:55.224"


### PR DESCRIPTION
The `open-email` events were often getting `undefined` as an identifier. This is because many of those emails come without being part of a campaign in Adobe. This PR fixes this issue, and makes some things for scoring a bit nicer in the process.

We will probably want to run all the campaign data through again (removing all of the existing data from Redshift and Postgres) because of #10 and this PR.