### PR TITLE
Bump Memory for Campaign Import Lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,7 @@ functions:
   campaign:
     handler: campaign/import.handler
     timeout: 300
+    memorySize: 512
     events:
       - schedule: cron(5 6 * * ? *)
   staticfiles:


### PR DESCRIPTION
This PR bumps the memory for the campaign import lambda from 256MB to 512MB.