### PR TITLE
Add acs_email to Ids Custom Context

### DIFF
--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -41,6 +41,7 @@ const track = (data, action) => {
 
   const ssoGuid = data['sso_guid']
   const grMasterPersonId = data['gr_master_person_id']
+  const acs_email = data['acs_email']
 
   const idData = { gr_master_person_id: grMasterPersonId }
 
@@ -48,11 +49,15 @@ const track = (data, action) => {
     idData.sso_guid = ssoGuid
   }
 
+  if (acs_email) {
+    idData.acs_email = acs_email
+  }
+
   const uri = buildUri(action, data)
 
   const customContexts = [
     {
-      schema: 'iglu:org.cru/ids/jsonschema/1-0-3',
+      schema: 'iglu:org.cru/ids/jsonschema/1-0-6',
       data: idData
     },
     {

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -23,7 +23,8 @@ describe('Campaign Snowplow', () => {
       ext_campaign_code: 'campaign-code',
       delivery_label: 'Some_Label - with [square brackets] (11/7/18) v.2',
       gr_master_person_id: 'some-gr-id',
-      log_date: '2018-07-30T09:20:49.333'
+      log_date: '2018-07-30T09:20:49.333',
+      acs_email: 'somerandomemail@test.com'
     }
 
     campaignSnowplow.trackEvent(data, 'opens')
@@ -34,7 +35,7 @@ describe('Campaign Snowplow', () => {
     const customContexts = [
       {
         schema: idSchema,
-        data: { gr_master_person_id: 'some-gr-id' }
+        data: { gr_master_person_id: 'some-gr-id', acs_email: 'somerandomemail@test.com' }
       },
       {
         schema: scoreSchema,
@@ -70,7 +71,8 @@ describe('Campaign Snowplow', () => {
     const data = {
       delivery_label: 'Some Label',
       gr_master_person_id: 'some-gr-id',
-      log_date: '2018-07-30T09:20:49.557'
+      log_date: '2018-07-30T09:20:49.557',
+      acs_email: 'somerandomemail@test.com'
     }
 
     campaignSnowplow.trackEvent(data, 'opens')
@@ -81,7 +83,7 @@ describe('Campaign Snowplow', () => {
     const customContexts = [
       {
         schema: idSchema,
-        data: { gr_master_person_id: 'some-gr-id' }
+        data: { gr_master_person_id: 'some-gr-id', acs_email: 'somerandomemail@test.com' }
       },
       {
         schema: scoreSchema,
@@ -118,7 +120,8 @@ describe('Campaign Snowplow', () => {
       delivery_label: 'Some Label',
       sso_guid: 'some-guid',
       gr_master_person_id: 'some-gr-id',
-      log_date: '2018-07-30T09:20:49.000'
+      log_date: '2018-07-30T09:20:49.000',
+      acs_email: 'somerandomemail@test.com'
     }
 
     campaignSnowplow.trackEvent(data, 'opens')
@@ -129,7 +132,7 @@ describe('Campaign Snowplow', () => {
     const customContexts = [
       {
         schema: idSchema,
-        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid' }
+        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid', acs_email: 'somerandomemail@test.com' }
       },
       {
         schema: scoreSchema,
@@ -168,7 +171,8 @@ describe('Campaign Snowplow', () => {
       sso_guid: 'some-guid',
       gr_master_person_id: 'some-gr-id',
       log_date: '2018-07-30T09:20:49.454',
-      click_url: 'https://www.cru.org'
+      click_url: 'https://www.cru.org',
+      acs_email: 'somerandomemail@test.com'
     }
 
     campaignSnowplow.trackEvent(data, 'clicks')
@@ -179,7 +183,7 @@ describe('Campaign Snowplow', () => {
     const customContexts = [
       {
         schema: idSchema,
-        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid' }
+        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid', acs_email: 'somerandomemail@test.com' }
       },
       {
         schema: scoreSchema,
@@ -218,7 +222,8 @@ describe('Campaign Snowplow', () => {
       sso_guid: 'some-guid',
       gr_master_person_id: 'some-gr-id',
       log_date: '2018-07-30T09:20:49.454',
-      click_url: 'https://www.cru.org'
+      click_url: 'https://www.cru.org',
+      acs_email: 'somerandomemail@test.com'
     }
 
     campaignSnowplow.trackEvent(data, 'clicks')
@@ -228,7 +233,7 @@ describe('Campaign Snowplow', () => {
     const customContexts = [
       {
         schema: idSchema,
-        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid' }
+        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid', acs_email: 'somerandomemail@test.com' }
       },
       {
         schema: scoreSchema,
@@ -267,7 +272,8 @@ describe('Campaign Snowplow', () => {
       origin: 'origin',
       sso_guid: 'some-guid',
       gr_master_person_id: 'some-gr-id',
-      log_date: '2018-08-10T17:04:50.419'
+      log_date: '2018-08-10T17:04:50.419', 
+      acs_email: 'somerandomemail@test.com'
     }
 
     campaignSnowplow.trackEvent(data, 'subscriptions')
@@ -278,7 +284,7 @@ describe('Campaign Snowplow', () => {
     const customContexts = [
       {
         schema: idSchema,
-        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid' }
+        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid', acs_email: 'somerandomemail@test.com' }
       },
       {
         schema: scoreSchema,
@@ -317,7 +323,8 @@ describe('Campaign Snowplow', () => {
       origin: 'origin',
       sso_guid: 'some-guid',
       gr_master_person_id: 'some-gr-id',
-      log_date: '2018-08-10T17:04:50.419'
+      log_date: '2018-08-10T17:04:50.419',
+      acs_email: 'somerandomemail@test.com'
     }
 
     campaignSnowplow.trackEvent(data, 'unsubscriptions')
@@ -328,7 +335,7 @@ describe('Campaign Snowplow', () => {
     const customContexts = [
       {
         schema: idSchema,
-        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid' }
+        data: { gr_master_person_id: 'some-gr-id', sso_guid: 'some-guid', acs_email: 'somerandomemail@test.com' }
       },
       {
         schema: scoreSchema,


### PR DESCRIPTION
We agreed on moving forward with this short term solution of updating the ACS workflows to send the emails, and then capturing them here. Talking with Wes, he suggested updating the ```ids``` custom entity to capture this email since it's technically an identifier. This cannot be merged yet until the new version of the ```ids``` schema is in production(version 1-0-6) and the ACS workflow is updated.