### PR TITLE
Add-ACS-Custom-Context

### DIFF
--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -47,15 +47,15 @@ const track = (data, action) => {
   const acsData = { acs_label: data['service_label'] ? data['service_label'] : data['delivery_label'] }
 
   if (ssoGuid) {
-    idData.sso_guid = ssoGuid
+    idData['sso_guid'] = ssoGuid
   }
 
   if (acsEmail) {
-    idData.acs_email = acsEmail
+    idData['acs_email'] = acsEmail
   }
 
   if (data['click_url']) {
-    acsData.acs_click_url = data['click_url']
+    acsData['acs_click_url'] = data['click_url']
   }
 
   const uri = buildUri(action, data)

--- a/campaign/snowplow.js
+++ b/campaign/snowplow.js
@@ -41,16 +41,21 @@ const track = (data, action) => {
 
   const ssoGuid = data['sso_guid']
   const grMasterPersonId = data['gr_master_person_id']
-  const acs_email = data['acs_email']
+  const acsEmail = data['acs_email']
 
   const idData = { gr_master_person_id: grMasterPersonId }
+  const acsData = { acs_label: data['service_label'] ? data['service_label'] : data['delivery_label'] }
 
   if (ssoGuid) {
     idData.sso_guid = ssoGuid
   }
 
-  if (acs_email) {
-    idData.acs_email = acs_email
+  if (acsEmail) {
+    idData.acs_email = acsEmail
+  }
+
+  if (data['click_url']) {
+    acsData.acs_click_url = data['click_url']
   }
 
   const uri = buildUri(action, data)
@@ -65,6 +70,10 @@ const track = (data, action) => {
       data: {
         uri: uri
       }
+    },
+    {
+      schema: 'iglu:org.cru/acs_context/jsonschema/1-0-0',
+      data: acsData
     }
   ]
 

--- a/campaign/snowplow.test.js
+++ b/campaign/snowplow.test.js
@@ -6,8 +6,9 @@ describe('Campaign Snowplow', () => {
     expect(campaignSnowplow).toBeDefined()
   })
 
-  const idSchema = 'iglu:org.cru/ids/jsonschema/1-0-3'
+  const idSchema = 'iglu:org.cru/ids/jsonschema/1-0-6'
   const scoreSchema = 'iglu:org.cru/content-scoring/jsonschema/1-0-0'
+  const acsSchema = 'iglu:org.cru/acs_context/jsonschema/1-0-0'
 
   it('Should track an open event with an external campaign code', () => {
     const mockTrackStructEvent = jest.fn()
@@ -41,6 +42,12 @@ describe('Campaign Snowplow', () => {
         schema: scoreSchema,
         data: {
           uri: uri
+        }
+      },
+      {
+        schema: acsSchema,
+        data: {
+          acs_label: data.delivery_label
         }
       }
     ]
@@ -90,6 +97,12 @@ describe('Campaign Snowplow', () => {
         data: {
           uri: uri
         }
+      },
+      {
+        schema: acsSchema,
+        data: {
+          acs_label: data.delivery_label
+        }
       }
     ]
 
@@ -138,6 +151,12 @@ describe('Campaign Snowplow', () => {
         schema: scoreSchema,
         data: {
           uri: uri
+        }
+      },
+      {
+        schema: acsSchema,
+        data: {
+          acs_label: data.delivery_label
         }
       }
     ]
@@ -190,6 +209,10 @@ describe('Campaign Snowplow', () => {
         data: {
           uri: uri
         }
+      },
+      {
+        schema: acsSchema,
+        data: { acs_label: data.delivery_label, acs_click_url: data.click_url }
       }
     ]
 
@@ -240,6 +263,12 @@ describe('Campaign Snowplow', () => {
         data: {
           uri: uri
         }
+      },
+      {
+        schema: acsSchema,
+        data: {
+          acs_label: data.delivery_label, acs_click_url: data.click_url
+        }
       }
     ]
 
@@ -272,7 +301,7 @@ describe('Campaign Snowplow', () => {
       origin: 'origin',
       sso_guid: 'some-guid',
       gr_master_person_id: 'some-gr-id',
-      log_date: '2018-08-10T17:04:50.419', 
+      log_date: '2018-08-10T17:04:50.419',
       acs_email: 'somerandomemail@test.com'
     }
 
@@ -291,6 +320,10 @@ describe('Campaign Snowplow', () => {
         data: {
           uri: uri
         }
+      },
+      {
+        schema: acsSchema,
+        data: { acs_label: data.service_label }
       }
     ]
 
@@ -341,6 +374,12 @@ describe('Campaign Snowplow', () => {
         schema: scoreSchema,
         data: {
           uri: uri
+        }
+      },
+      {
+        schema: acsSchema,
+        data: {
+          acs_label: data.service_label
         }
       }
     ]


### PR DESCRIPTION
I created a new custom context to capture these values for Tealium. Making them a specific defined value like ```acs_label``` is easier and more manageable on the Tealium side.